### PR TITLE
Add instructions for running from source rather than release

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ This inspector tries to keep the user interface minimal and very efficient: Just
 
 - Alternatively, you can install the contents of the `src` directory into your plugins folder.
 
-If you choose to run from source rather than use the release `rbz` file, you'll need to run from the `sketchup-attribute-inspector` folder:
+  If you choose to run from source rather than use the release `rbz` file, you'll need to run from the `sketchup-attribute-inspector` folder:
 
-```shell
-npm install
-npm build
-```
+  ```shell
+  npm install
+  npm build
+  ```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ This inspector tries to keep the user interface minimal and very efficient: Just
 
 - Alternatively, you can install the contents of the `src` directory into your plugins folder.
 
+If you choose to run from source rather than use the release `rbz` file, you'll need to run from the `sketchup-attribute-inspector` folder:
+
+```shell
+npm install
+npm build
+```
+
 ## Usage
 
 (Menu) `Window → Attribute Inspector`


### PR DESCRIPTION
If running from src dir, there will be no `js/main.js file`, and the window will
popup with a blank screen.